### PR TITLE
Adaptive time step for MHD

### DIFF
--- a/pyphare/pyphare/pharein/diagnostics.py
+++ b/pyphare/pyphare/pharein/diagnostics.py
@@ -5,6 +5,11 @@ from . import global_vars
 
 
 def all_timestamps(sim):
+    if sim.time_step is None:  # adaptive: no fixed step to build a dump grid from
+        raise RuntimeError(
+            "Error: with time_step_type='adaptive', diagnostics require explicit "
+            "'write_timestamps' (no default dump grid can be built without a fixed time_step)"
+        )
     init_time = sim.start_time()
     nbr_dump_step = int((sim.final_time - init_time) / sim.time_step) + 1
     return (sim.time_step * np.arange(nbr_dump_step)) + init_time
@@ -74,7 +79,9 @@ def validate_timestamps(clazz, key, **kwargs):
         )
     if not np.all(np.diff(timestamps) >= 0):
         raise RuntimeError(f"Error: {clazz}.{key} not in ascending order)")
-    if not np.all(
+    # with adaptive dt there is no fixed time_step to be a multiple of; dumps fire on a
+    # tolerance window (C++ DiagnosticsManager::needsAction_) instead.
+    if sim.time_step is not None and not np.all(
         np.abs(timestamps / sim.time_step - np.rint(timestamps / sim.time_step) < 1e-9)
     ):
         raise RuntimeError(

--- a/pyphare/pyphare/pharein/initialize/general.py
+++ b/pyphare/pyphare/pharein/initialize/general.py
@@ -107,14 +107,15 @@ def populateDict(sim):
 
     add_int("simulation/interp_order", sim.interp_order)
     add_int("simulation/refined_particle_nbr", sim.refined_particle_nbr)
-    add_string("simulation/time_step_type", sim.time_step_type)
+    # mirror the public `time_step` dict shape (mode + per-mode params) on the C++ side
+    add_string("simulation/time_step/mode", sim.time_step_type)
     if sim.time_step_type == "adaptive":
         # dt is computed each step on the C++ side; bound the run by final_time
-        add_double("simulation/time_step_cfl", sim.time_step_cfl)
-        add_double("simulation/time_step_fourier", sim.time_step_fourier)
+        add_double("simulation/time_step/cfl", sim.time_step_cfl)
+        add_double("simulation/time_step/fourier", sim.time_step_fourier)
         add_double("simulation/final_time", sim.final_time)
     else:
-        add_double("simulation/time_step", sim.time_step)
+        add_double("simulation/time_step/value", sim.time_step)
         add_int("simulation/time_step_nbr", sim.time_step_nbr)
 
     add_string("simulation/AMR/clustering", sim.clustering)

--- a/pyphare/pyphare/pharein/initialize/general.py
+++ b/pyphare/pyphare/pharein/initialize/general.py
@@ -107,8 +107,15 @@ def populateDict(sim):
 
     add_int("simulation/interp_order", sim.interp_order)
     add_int("simulation/refined_particle_nbr", sim.refined_particle_nbr)
-    add_double("simulation/time_step", sim.time_step)
-    add_int("simulation/time_step_nbr", sim.time_step_nbr)
+    add_string("simulation/time_step_type", sim.time_step_type)
+    if sim.time_step_type == "adaptive":
+        # dt is computed each step on the C++ side; bound the run by final_time
+        add_double("simulation/time_step_cfl", sim.time_step_cfl)
+        add_double("simulation/time_step_fourier", sim.time_step_fourier)
+        add_double("simulation/final_time", sim.final_time)
+    else:
+        add_double("simulation/time_step", sim.time_step)
+        add_int("simulation/time_step_nbr", sim.time_step_nbr)
 
     add_string("simulation/AMR/clustering", sim.clustering)
     add_vector_int("simulation/AMR/nesting_buffer", sim.nesting_buffer)

--- a/pyphare/pyphare/pharein/initialize/mhd.py
+++ b/pyphare/pyphare/pharein/initialize/mhd.py
@@ -1,6 +1,6 @@
 import pybindlibs.dictator as pp
 
-from .general import add_double, add_int, add_string, fn_wrapper
+from .general import add_bool, add_double, add_int, add_string, fn_wrapper
 
 
 def populateDict(sim):
@@ -15,6 +15,8 @@ def populateDict(sim):
     add_double("simulation/algo/fv_method/hyper_resistivity", sim.nu)
     add_double("simulation/algo/fv_method/heat_capacity_ratio", sim.gamma)
     add_string("simulation/algo/fv_method/hyper_mode", sim.hyper_mode)
+    # runtime flag for the adaptive-dt whistler term (consistent with the compile-time Hall perm)
+    add_bool("simulation/algo/fv_method/hall", sim.hall)
     add_double("simulation/algo/to_primitive/heat_capacity_ratio", sim.gamma)
     add_double("simulation/algo/to_conservative/heat_capacity_ratio", sim.gamma)
     add_double("simulation/algo/constrained_transport/resistivity", sim.eta)

--- a/pyphare/pyphare/pharein/restarts.py
+++ b/pyphare/pyphare/pharein/restarts.py
@@ -116,7 +116,7 @@ def validate(sim):
             raise RuntimeError(
                 "Error: restart_options timestamps not in ascending order)"
             )
-        if not np.all(
+        if sim.time_step is not None and not np.all(
             np.abs(
                 timestamps / sim.time_step - np.rint(timestamps / sim.time_step) < 1e-9
             )

--- a/pyphare/pyphare/pharein/simulation.py
+++ b/pyphare/pyphare/pharein/simulation.py
@@ -140,11 +140,41 @@ def check_domain(**kwargs):
 # ------------------------------------------------------------------------------
 
 
+def check_adaptive_time(**kwargs):
+    """
+    adaptive time_step_type: dt is recomputed each step from a CFL constraint.
+    The user supplies 'final_time' and 'time_step_cfl'; 'time_step'/'time_step_nbr' are not
+    allowed (imposing a step count with a variable dt is out of scope for now).
+    Returns (time_step_nbr, time_step, final_time) with the first two set to None.
+    """
+    if "final_time" not in kwargs or "time_step_cfl" not in kwargs:
+        raise ValueError(
+            "Error: adaptive time_step_type requires 'final_time' and 'time_step_cfl'"
+        )
+    if "time_step" in kwargs or "time_step_nbr" in kwargs:
+        raise ValueError(
+            "Error: adaptive time_step_type is incompatible with 'time_step'/'time_step_nbr'"
+        )
+    if kwargs["time_step_cfl"] <= 0:
+        raise ValueError("Error: 'time_step_cfl' must be > 0")
+
+    return None, None, kwargs["final_time"]
+
+
 def check_time(**kwargs):
     """
     check parameters relative to simulation duration and time resolution and raise exception if invalids
      return time_step_nbr and time_step
     """
+    time_step_type = kwargs.get("time_step_type", "constant")
+    if time_step_type not in ("constant", "adaptive"):
+        raise ValueError(
+            f"Error: unknown time_step_type '{time_step_type}', "
+            "expected 'constant' or 'adaptive'"
+        )
+    if time_step_type == "adaptive":
+        return check_adaptive_time(**kwargs)
+
     final_and_dt = (
         "final_time" in kwargs
         and "time_step" in kwargs
@@ -737,6 +767,9 @@ def checker(func):
             "final_time",
             "time_step",
             "time_step_nbr",
+            "time_step_type",
+            "time_step_cfl",
+            "time_step_fourier",
             "layout",
             "interp_order",
             "boundary_types",
@@ -795,6 +828,12 @@ def checker(func):
 
         kwargs["restart_options"] = check_restart_options(**kwargs)
 
+        kwargs["time_step_type"] = kwargs.get("time_step_type", "constant")
+        # diffusion (Fourier) coefficient for adaptive resistive dt; default to the advective CFL
+        # (BATSRUS-style: one knob unless the user splits them)
+        kwargs["time_step_fourier"] = kwargs.get(
+            "time_step_fourier", kwargs.get("time_step_cfl")
+        )
         time_step_nbr, time_step, final_time = check_time(**kwargs)
         kwargs["time_step_nbr"] = time_step_nbr
         kwargs["time_step"] = time_step
@@ -932,6 +971,11 @@ class Simulation(object):
         * **final_time** (``float``), final simulation time. Use with time_step OR time_step_nbr
         * **time_step** (``float``), simulation time step. Use with time_step_nbr OR final_time
         * **time_step_nbr** (``int``), number of time step to perform. Use with final_time OR time_step
+        * **time_step_type** (``str``), ``"constant"`` (default) or ``"adaptive"``. When ``"adaptive"``,
+          the time step is recomputed each step from a CFL constraint (MHD only); supply
+          ``final_time`` and ``time_step_cfl`` (not ``time_step``/``time_step_nbr``).
+        * **time_step_cfl** (``float``), advective CFL coefficient for adaptive time stepping. Normalized so 1 is the stability limit (sum-of-speeds form, dimension-independent); choose in (0, 1], typically ~0.3-0.5.
+        * **time_step_fourier** (``float``), resistive Fourier coefficient for adaptive time stepping. Normalized so 1 is the diffusion stability limit; choose in (0, 1]. Defaults to time_step_cfl. Only relevant when resistivity is non-zero.
 
 
         .. code-block:: python
@@ -1104,13 +1148,18 @@ class Simulation(object):
         self.stepDiff = 1 / self.nSubcycles
 
         levelNumbers = list(range(self.max_nbr_levels))
-        self.level_time_steps = [
-            self.time_step * (self.stepDiff ** (ilvl)) for ilvl in levelNumbers
-        ]
-        self.level_step_nbr = [
-            self.nSubcycles ** levelNumbers[ilvl] * self.time_step_nbr
-            for ilvl in levelNumbers
-        ]
+        # with adaptive dt, time_step/time_step_nbr are unknown ahead of the run
+        if self.time_step is None:
+            self.level_time_steps = None
+            self.level_step_nbr = None
+        else:
+            self.level_time_steps = [
+                self.time_step * (self.stepDiff ** (ilvl)) for ilvl in levelNumbers
+            ]
+            self.level_step_nbr = [
+                self.nSubcycles ** levelNumbers[ilvl] * self.time_step_nbr
+                for ilvl in levelNumbers
+            ]
         validate_restart_options(self)
 
     def simulation_domain(self):

--- a/pyphare/pyphare/pharein/simulation.py
+++ b/pyphare/pyphare/pharein/simulation.py
@@ -140,23 +140,70 @@ def check_domain(**kwargs):
 # ------------------------------------------------------------------------------
 
 
+def normalize_time_step(**kwargs):
+    """
+    Resolve the public 'time_step' option into the internal time_step_type / time_step_cfl /
+    time_step_fourier attributes. 'time_step' may be:
+      - a scalar (or absent)                          -> constant step
+      - {'mode': 'constant', 'value': <dt>}           -> constant step (dict form, 'value' optional)
+      - {'mode': 'adaptive', 'cfl': <c>, 'fourier': <f>}  -> adaptive step ('fourier' defaults to 'cfl')
+    Mutates and returns kwargs so downstream check_time() sees the resolved internal keys.
+    """
+    ts = kwargs.get("time_step", None)
+
+    if not isinstance(ts, dict):  # scalar value or absent
+        kwargs["time_step_type"] = "constant"
+        return kwargs
+
+    valid_modes = ("constant", "adaptive")
+    mode = ts.get("mode")
+    if mode not in valid_modes:
+        raise ValueError(
+            f"Error: time_step dict requires 'mode' in {valid_modes}, got {mode!r}"
+        )
+
+    def _check_keys(allowed):
+        extra = set(ts) - allowed
+        if extra:
+            raise ValueError(
+                f"Error: invalid time_step keys for mode '{mode}': {sorted(extra)}, "
+                f"allowed {sorted(allowed)}"
+            )
+
+    if mode == "constant":
+        _check_keys({"mode", "value"})
+        kwargs["time_step_type"] = "constant"
+        if "value" in ts:
+            kwargs["time_step"] = ts["value"]
+        else:
+            del kwargs["time_step"]  # let final_time + time_step_nbr combo apply
+    else:  # adaptive
+        _check_keys({"mode", "cfl", "fourier"})
+        if "cfl" not in ts:
+            raise ValueError("Error: adaptive time_step requires 'cfl'")
+        kwargs["time_step_type"] = "adaptive"
+        kwargs["time_step_cfl"] = ts["cfl"]
+        kwargs["time_step_fourier"] = ts.get("fourier", ts["cfl"])
+        del kwargs["time_step"]
+
+    return kwargs
+
+
 def check_adaptive_time(**kwargs):
     """
-    adaptive time_step_type: dt is recomputed each step from a CFL constraint.
-    The user supplies 'final_time' and 'time_step_cfl'; 'time_step'/'time_step_nbr' are not
+    adaptive time stepping: dt is recomputed each step from a CFL constraint.
+    The user supplies 'final_time' and a 'cfl' (via the time_step dict); 'time_step_nbr' is not
     allowed (imposing a step count with a variable dt is out of scope for now).
     Returns (time_step_nbr, time_step, final_time) with the first two set to None.
     """
-    if "final_time" not in kwargs or "time_step_cfl" not in kwargs:
-        raise ValueError(
-            "Error: adaptive time_step_type requires 'final_time' and 'time_step_cfl'"
-        )
+    if "final_time" not in kwargs:
+        raise ValueError("Error: adaptive time_step requires 'final_time'")
     if "time_step" in kwargs or "time_step_nbr" in kwargs:
         raise ValueError(
-            "Error: adaptive time_step_type is incompatible with 'time_step'/'time_step_nbr'"
+            "Error: adaptive time_step is incompatible with a constant 'time_step' / 'time_step_nbr'"
         )
     if kwargs["time_step_cfl"] <= 0:
-        raise ValueError("Error: 'time_step_cfl' must be > 0")
+        raise ValueError("Error: adaptive time_step 'cfl' must be > 0")
 
     return None, None, kwargs["final_time"]
 
@@ -167,11 +214,7 @@ def check_time(**kwargs):
      return time_step_nbr and time_step
     """
     time_step_type = kwargs.get("time_step_type", "constant")
-    if time_step_type not in ("constant", "adaptive"):
-        raise ValueError(
-            f"Error: unknown time_step_type '{time_step_type}', "
-            "expected 'constant' or 'adaptive'"
-        )
+    assert time_step_type in ("constant", "adaptive")  # set by normalize_time_step
     if time_step_type == "adaptive":
         return check_adaptive_time(**kwargs)
 
@@ -767,9 +810,6 @@ def checker(func):
             "final_time",
             "time_step",
             "time_step_nbr",
-            "time_step_type",
-            "time_step_cfl",
-            "time_step_fourier",
             "layout",
             "interp_order",
             "boundary_types",
@@ -828,12 +868,10 @@ def checker(func):
 
         kwargs["restart_options"] = check_restart_options(**kwargs)
 
-        kwargs["time_step_type"] = kwargs.get("time_step_type", "constant")
-        # diffusion (Fourier) coefficient for adaptive resistive dt; default to the advective CFL
-        # (BATSRUS-style: one knob unless the user splits them)
-        kwargs["time_step_fourier"] = kwargs.get(
-            "time_step_fourier", kwargs.get("time_step_cfl")
-        )
+        # resolve the public 'time_step' (scalar or dict) into internal
+        # time_step_type / time_step_cfl / time_step_fourier keys.
+        # (adaptive Fourier coefficient defaults to the advective CFL, BATSRUS-style.)
+        kwargs = normalize_time_step(**kwargs)
         time_step_nbr, time_step, final_time = check_time(**kwargs)
         kwargs["time_step_nbr"] = time_step_nbr
         kwargs["time_step"] = time_step

--- a/src/amr/multiphysics_integrator.hpp
+++ b/src/amr/multiphysics_integrator.hpp
@@ -33,6 +33,9 @@
 #include "core/logger.hpp"
 #include "core/utilities/algorithm.hpp"
 
+#include <limits>
+#include <algorithm>
+
 #include "load_balancing/load_balancer_manager.hpp"
 #include "load_balancing/load_balancer_estimator.hpp"
 #include "phare_core.hpp"
@@ -447,6 +450,48 @@ namespace solver
             // needs to be divided by ratio^2.
             // we multiply that by a constant < 1 for safety.
             return coarseDt / (ratio.max() * ratio.max()) /** 0.4*/;
+        }
+
+
+        /**
+         * @brief computeStableDt returns the adaptive coarse-level (L0) time step satisfying the
+         * CFL constraint on every existing level.
+         *
+         * Each level i is advanced with dt_i = dt_0 / prod_{j<=i} ratio_j^2 (the rigid cascade
+         * enforced by getMaxFinerLevelDt). Stability on level i therefore requires
+         * dt_0 <= dt_i^stable * prod_{j<=i} ratio_j^2. The tightest such bound wins, hence the min.
+         *
+         * Each solver.computeStableDt(...) already applies the cfl/fourier coefficients and reduces
+         * across ranks, returning its level's GLOBAL stable dt; the loop below is pure local
+         * arithmetic (projection + min) and yields the same dt_0 on every rank.
+         */
+        double computeStableDt(SAMRAI::hier::PatchHierarchy& hierarchy, double const cfl,
+                               double const fourier)
+        {
+            double dt0 = std::numeric_limits<double>::max();
+
+            // factor converting a level-i stable dt into its equivalent bound on the L0 dt:
+            // l0ProjectionFactor = prod_{j<=i} ratio_j^2  (so dt_0 <= dt_i^stable * factor)
+            double l0ProjectionFactor = 1.0;
+
+            for (int iLevel = 0; iLevel < hierarchy.getNumberOfLevels(); ++iLevel)
+            {
+                auto level = hierarchy.getPatchLevel(iLevel);
+
+                if (iLevel > 0)
+                {
+                    auto const r = static_cast<double>(level->getRatioToCoarserLevel().max());
+                    l0ProjectionFactor *= r * r;
+                }
+
+                // global per-level stable dt (solver applies cfl/fourier + cross-rank reduction)
+                auto const levelDt
+                    = getSolver_(iLevel).computeStableDt(getModel_(iLevel), *level, cfl, fourier);
+
+                dt0 = std::min(dt0, levelDt * l0ProjectionFactor);
+            }
+
+            return dt0;
         }
 
 

--- a/src/amr/solvers/solver.hpp
+++ b/src/amr/solvers/solver.hpp
@@ -11,6 +11,7 @@
 #include <SAMRAI/hier/PatchLevel.h>
 #include <SAMRAI/hier/PatchHierarchy.h>
 
+#include <limits>
 #include <string>
 
 
@@ -118,6 +119,26 @@ namespace solver
                               double const allocateTime) const
             = 0;
 
+
+
+        /**
+         * @brief computeStableDt returns the level's GLOBAL stable time step, already reduced
+         * across every rank the level is distributed over (so the value is identical on all ranks).
+         *
+         * It combines two stability buckets, each scaled by its own coefficient (both normalized so
+         * that 1 is the stability limit independent of dimension; choose in (0, 1]):
+         *   - advective (hyperbolic, incl. Hall whistler when active), scaled by @p cfl
+         *   - resistive (parabolic diffusion), scaled by @p fourier (Fourier number Fo =
+         *     eta*dt/dx^2)
+         * and returns their min.
+         *
+         * If not overriden by the actual Solver implementation, returns a very big double.
+         */
+        virtual double computeStableDt(IPhysicalModel_t& model, level_t& level, double const cfl,
+                                       double const fourier)
+        {
+            return std::numeric_limits<double>::max();
+        }
 
 
         virtual void onRegrid() {} // do what you need to do on regrid

--- a/src/amr/solvers/solver_mhd.hpp
+++ b/src/amr/solvers/solver_mhd.hpp
@@ -12,6 +12,8 @@
 #include "core/data/vecfield/vecfield_component.hpp"
 #include "core/numerics/godunov_fluxes/godunov_utils.hpp"
 #include "core/numerics/finite_volume_euler/finite_volume_euler.hpp"
+#include "core/numerics/riemann_solvers/mhd_speeds.hpp"
+#include "core/numerics/primite_conservative_converter/to_primitive_converter.hpp"
 
 #include "amr/solvers/solver.hpp"
 #include "amr/messengers/messenger.hpp"
@@ -40,14 +42,14 @@ class SolverMHD : public ISolver<AMR_Types>
 private:
     static constexpr auto dimension = MHDModel::dimension;
 
-    using patch_t     = typename AMR_Types::patch_t;
-    using level_t     = typename AMR_Types::level_t;
-    using hierarchy_t = typename AMR_Types::hierarchy_t;
+    using patch_t     = AMR_Types::patch_t;
+    using level_t     = AMR_Types::level_t;
+    using hierarchy_t = AMR_Types::hierarchy_t;
 
-    using FieldT      = typename MHDModel::field_type;
-    using VecFieldT   = typename MHDModel::vecfield_type;
-    using MHDStateT   = typename MHDModel::state_type;
-    using GridLayout  = typename MHDModel::gridlayout_type;
+    using FieldT      = MHDModel::field_type;
+    using VecFieldT   = MHDModel::vecfield_type;
+    using MHDStateT   = MHDModel::state_type;
+    using GridLayout  = MHDModel::gridlayout_type;
     using MHDQuantity = core::MHDQuantity;
 
     using IPhysicalModel_t = IPhysicalModel<AMR_Types>;
@@ -65,6 +67,11 @@ private:
     EulerUsingComputedFlux<MHDModel> reflux_euler_;
 
     std::unordered_map<std::size_t, double> oldTime_;
+
+    // adaptive-timestep coefficients (read from the algo dict, mirror ComputeFluxes/CT keys)
+    double const gamma_; // adiabatic index (advective fast speed)
+    double const eta_;   // resistivity (parabolic / Fourier bucket)
+    bool const hall_;    // Hall active -> add whistler speed to the advective bucket
 
 public:
     SolverMHD(PHARE::initializer::PHAREDict const& dict)
@@ -98,6 +105,9 @@ public:
                    {"sumRhoV_fz", MHDQuantity::Vector::VecFlux_z},
                    {"sumB_fz", MHDQuantity::Vector::VecFlux_z},
                    {"sumEtot_fz", MHDQuantity::Scalar::ScalarFlux_z}}
+        , gamma_{dict["to_primitive"]["heat_capacity_ratio"].template to<double>()}
+        , eta_{dict["constrained_transport"]["resistivity"].template to<double>()}
+        , hall_{cppdict::get_value(dict, "fv_method/hall", false)}
     {
     }
 
@@ -127,6 +137,9 @@ public:
     void advanceLevel(hierarchy_t const& hierarchy, int const levelNumber, IPhysicalModel_t& model,
                       IMessenger& fromCoarserMessenger, double const currentTime,
                       double const newTime) override;
+
+    double computeStableDt(IPhysicalModel_t& model, SAMRAI::hier::PatchLevel& level,
+                           double const cfl, double const fourier) override;
 
     void onRegrid() override {}
 
@@ -429,6 +442,89 @@ void SolverMHD<MHDModel, AMR_Types, TimeIntegratorStrategy, Messenger>::advanceL
 
     if (core::mpi::any_errors())
         throw core::DictionaryException{}("ID", "SolverMHD::advanceLevel");
+}
+
+template<typename MHDModel, typename AMR_Types, typename TimeIntegratorStrategy, typename Messenger>
+double SolverMHD<MHDModel, AMR_Types, TimeIntegratorStrategy, Messenger>::computeStableDt(
+    IPhysicalModel_t& model, SAMRAI::hier::PatchLevel& level, double const cfl,
+    double const fourier)
+{
+    PHARE_LOG_SCOPE(1, "SolverMHD::computeStableDt");
+
+    auto& mhdModel = dynamic_cast<MHDModel&>(model);
+    auto& rho      = mhdModel.state.rho;
+    auto& rhoV     = mhdModel.state.rhoV;
+    auto& B        = mhdModel.state.B;
+    auto& Etot     = mhdModel.state.Etot;
+
+    // Two stability buckets, combined by min. Both coefficients are normalized so that the value
+    // 1 sits exactly on the (forward-Euler / SSP-RK) stability limit, independent of dimension, so
+    // cfl, fourier are meant to be chosen in (0, 1]:
+    //   - advective: dt = cfl / sum_d (|v_d| + c_fast_d [+ c_whistler_d if Hall]) / dx_d
+    //   - resistive: dt = fourier / (2 * eta * sum_d 1/dx_d^2)   (eta uniform)
+    // The level's patches are distributed across ranks, so the local min below is reduced across
+    // ranks before returning. The inter-level projection is applied by the caller.
+    double dt = std::numeric_limits<double>::max();
+
+    amr::visitLevel<GridLayout>(
+        level, *mhdModel.resourcesManager,
+        [&](auto& layout, std::string const&, std::size_t const) {
+            auto const meshSize = layout.meshSize();
+
+            // resistive (Fourier) bucket: eta uniform -> one value per patch, no cell loop needed
+            if (eta_ > 0)
+            {
+                double invdx2 = 0;
+                for (std::size_t d = 0; d < dimension; ++d)
+                    invdx2 += 1.0 / (meshSize[d] * meshSize[d]);
+                dt = std::min(dt, fourier / (2.0 * eta_ * invdx2));
+            }
+
+            auto const& rhoVx = rhoV(core::Component::X);
+            auto const& rhoVy = rhoV(core::Component::Y);
+            auto const& rhoVz = rhoV(core::Component::Z);
+            auto const& Bx    = B(core::Component::X);
+            auto const& By    = B(core::Component::Y);
+            auto const& Bz    = B(core::Component::Z);
+
+            // advective (+ Hall whistler) bucket: per cell, sum-of-speeds form
+            layout.evalOnBox(rho, [&](auto&... args) mutable {
+                core::MeshIndex<dimension> const index{args...};
+
+                auto const r  = rho(index);
+                auto const vx = rhoVx(index) / r;
+                auto const vy = rhoVy(index) / r;
+                auto const vz = rhoVz(index) / r;
+                // cell-center the face-centered (Yee) B, same idiom as ToPrimitiveConverter
+                auto const bx
+                    = GridLayout::template project<GridLayout::faceXToCellCenter>(Bx, index);
+                auto const by
+                    = GridLayout::template project<GridLayout::faceYToCellCenter>(By, index);
+                auto const bz
+                    = GridLayout::template project<GridLayout::faceZToCellCenter>(Bz, index);
+
+                auto const BdotB = bx * bx + by * by + bz * bz;
+                auto const P     = core::eosEtotToP(gamma_, r, vx, vy, vz, bx, by, bz, Etot(index));
+
+                std::array<double, 3> const v{vx, vy, vz};
+                std::array<double, 3> const b{bx, by, bz};
+
+                // sum_d (|v_d| + c_fast_d + c_whistler_d) / dx_d over simulated directions
+                double invDtAdv = 0;
+                for (std::size_t d = 0; d < dimension; ++d)
+                {
+                    auto const cfast = core::compute_fast_magnetosonic_(gamma_, r, b[d], BdotB, P);
+                    // Hall whistler
+                    auto const cw
+                        = hall_ ? core::compute_whistler_(1.0 / meshSize[d], r, BdotB) : 0.0;
+                    invDtAdv += (std::abs(v[d]) + cfast + cw) / meshSize[d];
+                }
+                dt = std::min(dt, cfl / invDtAdv);
+            });
+        },
+        rho, rhoV, B, Etot);
+
+    return core::mpi::min(dt); // reduce across the ranks the level is distributed over
 }
 
 template<typename MHDModel, typename AMR_Types, typename TimeIntegratorStrategy, typename Messenger>

--- a/src/core/utilities/mpi_utils.cpp
+++ b/src/core/utilities/mpi_utils.cpp
@@ -37,6 +37,15 @@ std::size_t max(std::size_t const local, int mpi_size)
 
 
 
+double min(double const local)
+{
+    double global;
+    MPI_Allreduce(&local, &global, 1, MPI_DOUBLE, MPI_MIN, MPI_COMM_WORLD);
+    return global;
+}
+
+
+
 bool any(bool b)
 {
     int global_sum, local_sum = static_cast<int>(b);

--- a/src/core/utilities/mpi_utils.hpp
+++ b/src/core/utilities/mpi_utils.hpp
@@ -24,6 +24,8 @@ NO_DISCARD std::vector<Data> collect(Data const& data, int mpi_size = 0);
 
 NO_DISCARD std::size_t max(std::size_t const local, int mpi_size = 0);
 
+NO_DISCARD double min(double const local);
+
 NO_DISCARD bool any(bool);
 NO_DISCARD bool any_errors();
 void log_error(std::string const key, std::string const val);

--- a/src/core/utilities/timestamps.hpp
+++ b/src/core/utilities/timestamps.hpp
@@ -74,13 +74,14 @@ struct TimeStamperFactory
 {
     NO_DISCARD static std::unique_ptr<ITimeStamper> create(initializer::PHAREDict const& dict)
     {
-        if (dict.contains("time_step_type")
-            && dict["time_step_type"].template to<std::string>() == "adaptive")
+        auto const& time_step_dict = dict["time_step"];
+        if (time_step_dict.contains("mode")
+            && time_step_dict["mode"].template to<std::string>() == "adaptive")
             // dt_ seed is irrelevant: the first (varying) dt resets it on the first step
             return std::make_unique<VariableTimeStamper>(0.);
 
-        assert(dict.contains("time_step"));
-        auto time_step  = dict["time_step"].template to<double>();
+        assert(time_step_dict.contains("value"));
+        auto time_step  = time_step_dict["value"].template to<double>();
         std::size_t idx = 0;
 
         return std::make_unique<ConstantTimeStamper>(time_step, idx);

--- a/src/core/utilities/timestamps.hpp
+++ b/src/core/utilities/timestamps.hpp
@@ -39,15 +39,50 @@ private:
     std::size_t idx_ = 0;
 };
 
+// Accumulates the (possibly varying) dt actually used at each step, for adaptive time stepping.
+class VariableTimeStamper : public ITimeStamper
+{
+public:
+    VariableTimeStamper(double const& dt, double const& init_time = 0)
+        : dt_{dt}
+        , last_change_{init_time}
+        , last_time_(init_time)
+    {
+    }
+
+    double operator+=(double const& new_dt) noexcept override
+    {
+        assert(new_dt > 0);
+
+        if (new_dt != dt_) // not sure if safe, possibly
+        {
+            dt_          = new_dt;
+            last_change_ = last_time_;
+            n_same_      = 0;
+        }
+        return (last_time_ = last_change_ + (dt_ * ++n_same_));
+    }
+
+private:
+    std::size_t n_same_ = 0;
+    double dt_          = 0;
+    double last_change_ = 0;
+    double last_time_   = 0;
+};
+
 struct TimeStamperFactory
 {
     NO_DISCARD static std::unique_ptr<ITimeStamper> create(initializer::PHAREDict const& dict)
     {
+        if (dict.contains("time_step_type")
+            && dict["time_step_type"].template to<std::string>() == "adaptive")
+            // dt_ seed is irrelevant: the first (varying) dt resets it on the first step
+            return std::make_unique<VariableTimeStamper>(0.);
+
         assert(dict.contains("time_step"));
         auto time_step  = dict["time_step"].template to<double>();
         std::size_t idx = 0;
 
-        // only option for the moment https://github.com/PHAREHUB/PHARE/issues/475
         return std::make_unique<ConstantTimeStamper>(time_step, idx);
     }
 };

--- a/src/simulator/simulator.hpp
+++ b/src/simulator/simulator.hpp
@@ -26,6 +26,8 @@
 #include <stdexcept>
 #include <vector>
 #include <string>
+#include <limits>
+#include <algorithm>
 
 
 
@@ -101,7 +103,20 @@ public:
 
     NO_DISCARD double startTime() override { return startTime_; }
     NO_DISCARD double endTime() override { return finalTime_; }
-    NO_DISCARD double timeStep() override { return dt_; }
+    NO_DISCARD double timeStep() override
+    {
+        if (timeStepType_ != "adaptive")
+            return dt_;
+
+        // recompute the CFL-stable dt once per coarse step (timeStep() is queried from several
+        // Python sites at the same currentTime_); clamp the final step to land on finalTime_.
+        if (cachedDtTime_ != currentTime_)
+        {
+            cachedDt_     = multiphysInteg_->computeStableDt(*hierarchy_, cfl_, fourier_);
+            cachedDtTime_ = currentTime_;
+        }
+        return std::min(cachedDt_, finalTime_ - currentTime_);
+    }
     NO_DISCARD double currentTime() override { return currentTime_; }
 
     void initialize() override;
@@ -181,10 +196,16 @@ private:
     int maxLevelNumber_;
     int maxMHDLevel_;
     double dt_;
-    int timeStepNbr_           = 0;
-    double startTime_          = 0;
-    double finalTime_          = 0;
-    double currentTime_        = 0;
+    std::string timeStepType_ = "constant";
+    double cfl_               = 0; // advective CFL coefficient (adaptive)
+    double fourier_           = 0; // resistive Fourier number Fo = eta*dt/dx^2 (adaptive)
+    int timeStepNbr_          = 0;
+    double startTime_         = 0;
+    double finalTime_         = 0;
+    double currentTime_       = 0;
+    // adaptive-dt memo: recompute the stable dt once per coarse step (per distinct currentTime_)
+    double cachedDt_     = 0;
+    double cachedDtTime_ = std::numeric_limits<double>::lowest();
     std::size_t fineDumpLvlMax = 0;
     bool isInitialized         = false;
 
@@ -422,8 +443,12 @@ Simulator<opts>::Simulator(PHARE::initializer::PHAREDict const& dict,
     , messengerFactory_{descriptors_}
     , maxLevelNumber_{dict["simulation"]["AMR"]["max_nbr_levels"].template to<int>()}
     , maxMHDLevel_{dict["simulation"]["AMR"]["max_mhd_level"].template to<int>()}
-    , dt_{dict["simulation"]["time_step"].template to<double>()}
-    , timeStepNbr_{dict["simulation"]["time_step_nbr"].template to<int>()}
+    // time_step / time_step_nbr are absent in the adaptive case (see ctor body for finalTime_)
+    , dt_{cppdict::get_value(dict, "simulation/time_step", 0.)}
+    , timeStepType_{cppdict::get_value(dict, "simulation/time_step_type", std::string{"constant"})}
+    , cfl_{cppdict::get_value(dict, "simulation/time_step_cfl", 0.)}
+    , fourier_{cppdict::get_value(dict, "simulation/time_step_fourier", 0.)}
+    , timeStepNbr_{cppdict::get_value(dict, "simulation/time_step_nbr", 0)}
     , finalTime_{dt_ * timeStepNbr_}
     , functors_{functors_setup(dict)}
     , multiphysInteg_{std::make_shared<MultiPhysicsIntegrator>(dict["simulation"], functors_)}
@@ -432,7 +457,11 @@ Simulator<opts>::Simulator(PHARE::initializer::PHAREDict const& dict,
         throw std::runtime_error("NO HIERARCHY!");
 
     currentTime_ = restart_time(dict);
-    finalTime_ += currentTime_; // final time is from timestep * timestep_nbr!
+    if (timeStepType_ == "adaptive")
+        // dt is computed each step; the run is bounded by final_time directly
+        finalTime_ = currentTime_ + dict["simulation"]["final_time"].template to<double>();
+    else
+        finalTime_ += currentTime_; // final time is from timestep * timestep_nbr!
 
 
     // we would need a different restart manager for mhd and hybrid if both models are used

--- a/src/simulator/simulator.hpp
+++ b/src/simulator/simulator.hpp
@@ -443,11 +443,11 @@ Simulator<opts>::Simulator(PHARE::initializer::PHAREDict const& dict,
     , messengerFactory_{descriptors_}
     , maxLevelNumber_{dict["simulation"]["AMR"]["max_nbr_levels"].template to<int>()}
     , maxMHDLevel_{dict["simulation"]["AMR"]["max_mhd_level"].template to<int>()}
-    // time_step / time_step_nbr are absent in the adaptive case (see ctor body for finalTime_)
-    , dt_{cppdict::get_value(dict, "simulation/time_step", 0.)}
-    , timeStepType_{cppdict::get_value(dict, "simulation/time_step_type", std::string{"constant"})}
-    , cfl_{cppdict::get_value(dict, "simulation/time_step_cfl", 0.)}
-    , fourier_{cppdict::get_value(dict, "simulation/time_step_fourier", 0.)}
+    // time_step/value and time_step_nbr are absent in the adaptive case (see ctor body for finalTime_)
+    , dt_{cppdict::get_value(dict, "simulation/time_step/value", 0.)}
+    , timeStepType_{cppdict::get_value(dict, "simulation/time_step/mode", std::string{"constant"})}
+    , cfl_{cppdict::get_value(dict, "simulation/time_step/cfl", 0.)}
+    , fourier_{cppdict::get_value(dict, "simulation/time_step/fourier", 0.)}
     , timeStepNbr_{cppdict::get_value(dict, "simulation/time_step_nbr", 0)}
     , finalTime_{dt_ * timeStepNbr_}
     , functors_{functors_setup(dict)}

--- a/tests/simulator/CMakeLists.txt
+++ b/tests/simulator/CMakeLists.txt
@@ -11,6 +11,7 @@ endif()
 phare_python3_exec(9 validation           test_validation.py      ${CMAKE_CURRENT_BINARY_DIR})
 phare_python3_exec(9 data-wrangler        data_wrangler.py        ${CMAKE_CURRENT_BINARY_DIR})
 add_no_mpi_python3_test(periodicity test_init_periodicity.py ${CMAKE_CURRENT_BINARY_DIR})
+add_no_mpi_python3_test(time_step test_time_step.py ${CMAKE_CURRENT_BINARY_DIR})
 
 if (useExceptionsInsteadOfMPIAbort)
   add_no_mpi_python3_test(exceptions test_exceptions.py ${CMAKE_CURRENT_BINARY_DIR})

--- a/tests/simulator/test_time_step.py
+++ b/tests/simulator/test_time_step.py
@@ -1,0 +1,124 @@
+#
+# Config-level validation tests for the time_step_type option (constant vs adaptive).
+# These only construct ph.Simulation (pharein) and never run the simulator, so they are cheap
+# and need no cpp module / MPI / HighFive.
+#
+
+import unittest
+import numpy as np
+import pyphare.pharein as ph
+
+# minimal valid geometry; time parameters are supplied per-test
+baseArgs = dict(
+    boundary_types="periodic",
+    cells=np.array([20]),
+    dl=0.3,
+)
+
+
+# pure pharein config validation: never runs the simulator, so no MPI / cpp module needed
+class TimeStepValidation(unittest.TestCase):
+    def setUp(self):
+        ph.global_vars.sim = None
+
+    def tearDown(self):
+        ph.global_vars.sim = None
+
+    # ---- constant (default, backward compatible) -------------------------------------------
+
+    def test_constant_is_the_default(self):
+        sim = ph.Simulation(time_step=0.001, time_step_nbr=10, **baseArgs)
+        self.assertEqual(sim.time_step_type, "constant")
+        self.assertEqual(sim.time_step, 0.001)
+        self.assertEqual(sim.time_step_nbr, 10)
+
+    def test_constant_explicit(self):
+        sim = ph.Simulation(
+            time_step_type="constant", time_step=0.001, final_time=1.0, **baseArgs
+        )
+        self.assertEqual(sim.time_step_type, "constant")
+        self.assertEqual(sim.time_step, 0.001)
+
+    # ---- adaptive --------------------------------------------------------------------------
+
+    def test_adaptive_accepts_final_time_and_cfl(self):
+        sim = ph.Simulation(
+            time_step_type="adaptive",
+            time_step_cfl=0.4,
+            final_time=1.0,
+            **baseArgs,
+        )
+        self.assertEqual(sim.time_step_type, "adaptive")
+        self.assertEqual(sim.time_step_cfl, 0.4)
+        self.assertEqual(sim.final_time, 1.0)
+        # with adaptive dt these are unknown ahead of the run
+        self.assertIsNone(sim.time_step)
+        self.assertIsNone(sim.time_step_nbr)
+
+    def test_adaptive_fourier_defaults_to_cfl(self):
+        sim = ph.Simulation(
+            time_step_type="adaptive", time_step_cfl=0.4, final_time=1.0, **baseArgs
+        )
+        self.assertEqual(sim.time_step_fourier, 0.4)
+
+    def test_adaptive_fourier_explicit(self):
+        sim = ph.Simulation(
+            time_step_type="adaptive",
+            time_step_cfl=0.4,
+            time_step_fourier=0.2,
+            final_time=1.0,
+            **baseArgs,
+        )
+        self.assertEqual(sim.time_step_fourier, 0.2)
+
+    def test_adaptive_requires_cfl(self):
+        with self.assertRaises(ValueError):
+            ph.Simulation(time_step_type="adaptive", final_time=1.0, **baseArgs)
+
+    def test_adaptive_requires_final_time(self):
+        with self.assertRaises(ValueError):
+            ph.Simulation(time_step_type="adaptive", time_step_cfl=0.4, **baseArgs)
+
+    def test_adaptive_rejects_time_step(self):
+        with self.assertRaises(ValueError):
+            ph.Simulation(
+                time_step_type="adaptive",
+                time_step_cfl=0.4,
+                final_time=1.0,
+                time_step=0.001,
+                **baseArgs,
+            )
+
+    def test_adaptive_rejects_time_step_nbr(self):
+        with self.assertRaises(ValueError):
+            ph.Simulation(
+                time_step_type="adaptive",
+                time_step_cfl=0.4,
+                final_time=1.0,
+                time_step_nbr=10,
+                **baseArgs,
+            )
+
+    def test_adaptive_rejects_non_positive_cfl(self):
+        with self.assertRaises(ValueError):
+            ph.Simulation(
+                time_step_type="adaptive",
+                time_step_cfl=0.0,
+                final_time=1.0,
+                **baseArgs,
+            )
+
+    # ---- unknown keyword -------------------------------------------------------------------
+
+    def test_unknown_time_step_type_raises(self):
+        with self.assertRaises(ValueError):
+            ph.Simulation(
+                time_step_type="variable",  # common mistake: the option is "adaptive"
+                time_step_cfl=0.4,
+                final_time=1.0,
+                **baseArgs,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/simulator/test_time_step.py
+++ b/tests/simulator/test_time_step.py
@@ -1,5 +1,5 @@
 #
-# Config-level validation tests for the time_step_type option (constant vs adaptive).
+# Config-level validation tests for the time_step option (constant scalar vs adaptive dict).
 # These only construct ph.Simulation (pharein) and never run the simulator, so they are cheap
 # and need no cpp module / MPI / HighFive.
 #
@@ -24,7 +24,7 @@ class TimeStepValidation(unittest.TestCase):
     def tearDown(self):
         ph.global_vars.sim = None
 
-    # ---- constant (default, backward compatible) -------------------------------------------
+    # ---- constant (scalar time_step, default) ----------------------------------------------
 
     def test_constant_is_the_default(self):
         sim = ph.Simulation(time_step=0.001, time_step_nbr=10, **baseArgs)
@@ -32,19 +32,39 @@ class TimeStepValidation(unittest.TestCase):
         self.assertEqual(sim.time_step, 0.001)
         self.assertEqual(sim.time_step_nbr, 10)
 
-    def test_constant_explicit(self):
-        sim = ph.Simulation(
-            time_step_type="constant", time_step=0.001, final_time=1.0, **baseArgs
-        )
+    def test_constant_final_time_and_step(self):
+        sim = ph.Simulation(time_step=0.001, final_time=1.0, **baseArgs)
         self.assertEqual(sim.time_step_type, "constant")
         self.assertEqual(sim.time_step, 0.001)
 
-    # ---- adaptive --------------------------------------------------------------------------
+    def test_constant_final_time_and_nbr_has_no_time_step_kwarg(self):
+        sim = ph.Simulation(time_step_nbr=10, final_time=1.0, **baseArgs)
+        self.assertEqual(sim.time_step_type, "constant")
+        self.assertEqual(sim.time_step_nbr, 10)
+
+    def test_constant_dict_with_value(self):
+        sim = ph.Simulation(
+            time_step={"mode": "constant", "value": 0.001},
+            time_step_nbr=10,
+            **baseArgs,
+        )
+        self.assertEqual(sim.time_step_type, "constant")
+        self.assertEqual(sim.time_step, 0.001)
+        self.assertEqual(sim.time_step_nbr, 10)
+
+    def test_constant_dict_rejects_unknown_key(self):
+        with self.assertRaises(ValueError):
+            ph.Simulation(
+                time_step={"mode": "constant", "dt": 0.001},  # key is "value"
+                final_time=1.0,
+                **baseArgs,
+            )
+
+    # ---- adaptive (dict time_step) ---------------------------------------------------------
 
     def test_adaptive_accepts_final_time_and_cfl(self):
         sim = ph.Simulation(
-            time_step_type="adaptive",
-            time_step_cfl=0.4,
+            time_step={"mode": "adaptive", "cfl": 0.4},
             final_time=1.0,
             **baseArgs,
         )
@@ -57,15 +77,13 @@ class TimeStepValidation(unittest.TestCase):
 
     def test_adaptive_fourier_defaults_to_cfl(self):
         sim = ph.Simulation(
-            time_step_type="adaptive", time_step_cfl=0.4, final_time=1.0, **baseArgs
+            time_step={"mode": "adaptive", "cfl": 0.4}, final_time=1.0, **baseArgs
         )
         self.assertEqual(sim.time_step_fourier, 0.4)
 
     def test_adaptive_fourier_explicit(self):
         sim = ph.Simulation(
-            time_step_type="adaptive",
-            time_step_cfl=0.4,
-            time_step_fourier=0.2,
+            time_step={"mode": "adaptive", "cfl": 0.4, "fourier": 0.2},
             final_time=1.0,
             **baseArgs,
         )
@@ -73,27 +91,18 @@ class TimeStepValidation(unittest.TestCase):
 
     def test_adaptive_requires_cfl(self):
         with self.assertRaises(ValueError):
-            ph.Simulation(time_step_type="adaptive", final_time=1.0, **baseArgs)
+            ph.Simulation(
+                time_step={"mode": "adaptive"}, final_time=1.0, **baseArgs
+            )
 
     def test_adaptive_requires_final_time(self):
         with self.assertRaises(ValueError):
-            ph.Simulation(time_step_type="adaptive", time_step_cfl=0.4, **baseArgs)
-
-    def test_adaptive_rejects_time_step(self):
-        with self.assertRaises(ValueError):
-            ph.Simulation(
-                time_step_type="adaptive",
-                time_step_cfl=0.4,
-                final_time=1.0,
-                time_step=0.001,
-                **baseArgs,
-            )
+            ph.Simulation(time_step={"mode": "adaptive", "cfl": 0.4}, **baseArgs)
 
     def test_adaptive_rejects_time_step_nbr(self):
         with self.assertRaises(ValueError):
             ph.Simulation(
-                time_step_type="adaptive",
-                time_step_cfl=0.4,
+                time_step={"mode": "adaptive", "cfl": 0.4},
                 final_time=1.0,
                 time_step_nbr=10,
                 **baseArgs,
@@ -102,19 +111,25 @@ class TimeStepValidation(unittest.TestCase):
     def test_adaptive_rejects_non_positive_cfl(self):
         with self.assertRaises(ValueError):
             ph.Simulation(
-                time_step_type="adaptive",
-                time_step_cfl=0.0,
+                time_step={"mode": "adaptive", "cfl": 0.0},
                 final_time=1.0,
                 **baseArgs,
             )
 
-    # ---- unknown keyword -------------------------------------------------------------------
-
-    def test_unknown_time_step_type_raises(self):
+    def test_adaptive_rejects_unknown_dict_key(self):
         with self.assertRaises(ValueError):
             ph.Simulation(
-                time_step_type="variable",  # common mistake: the option is "adaptive"
-                time_step_cfl=0.4,
+                time_step={"mode": "adaptive", "cfl": 0.4, "courant": 0.2},
+                final_time=1.0,
+                **baseArgs,
+            )
+
+    # ---- unknown mode ----------------------------------------------------------------------
+
+    def test_unknown_mode_raises(self):
+        with self.assertRaises(ValueError):
+            ph.Simulation(
+                time_step={"mode": "variable", "cfl": 0.4},  # only "adaptive" is valid
                 final_time=1.0,
                 **baseArgs,
             )


### PR DESCRIPTION
 Solves https://github.com/PHAREHUB/PHARE/issues/1184

## Summary

Adaptive coarse-level (L0) `dt`: in adaptive mode L0 `dt` is recomputed each step from a stability constraint; SAMRAI's `ratio²` subcycling cascade is left unchanged — only L0 `dt` becomes dynamic and finer levels follow via `getMaxFinerLevelDt`. Default is constant, fully backward compatible.

## Config API

A single overloaded `time_step` option (matches the existing dict-option pattern of `diag_options` / `restart_options`):

```python
time_step = 0.1                                          # constant (scalar)
time_step = {'mode': 'constant', 'value': 0.1}           # constant (dict form)
time_step = {'mode': 'adaptive', 'cfl': 0.9, 'fourier': 0.5}  # adaptive
```

- Dict requires an explicit `mode` and rejects stray keys.
- Adaptive: `cfl` required, `fourier` defaults to `cfl`.
- Resolved by `normalize_time_step()` into internal `time_step_type` / `time_step_cfl` / `time_step_fourier` attributes. The same dict shape is mirrored in the C++ `PHAREDict` (`simulation/time_step/{mode,value,cfl,fourier}`), read nested in `simulator.hpp` and `timestamps.hpp`.

## How dt is computed

Per level, the solver computes (and MPI-reduces across the ranks the level is distributed over) the min over cells of two buckets; the integrator then applies the `ratio^(2i)` projection and takes the min over levels:

```
advective: dt = cfl     / Σ_d (|v_d| + c_fast_d + c_whistler_d) / dx_d
resistive: dt = fourier / (2 · η · Σ_d 1/dx_d²)
```

- `cfl` + `fourier` are **normalized so 1 is the stability limit** independent of dimension (choose in `(0,1]`); `fourier` defaults to `cfl`.
- **Whistler** speed (`compute_whistler_`) added to the advective bucket when **Hall** is active
- **Hyper-resistivity** constraint intentionally **not** handled.
- `VariableTimeStamper` (from #475) accumulates the varying `dt`; the constant path / `ConstantTimeStamper` are untouched.
- Config validation: adaptive requires `final_time`, rejects a constant `time_step` / `time_step_nbr`, and errors on an unknown `mode`.

## Testing

- `tests/simulator/test_time_step.py` — config-validation unit tests (scalar/dict constant, adaptive, mode required, stray-key + bad-mode rejection)
- Manually verified the C++ kernel: ideal sum-form dt, exact Fourier-limited dt (`= fourier/(2η·Σ)`), whistler `dt~dx²` scaling responding to `cfl`; constant path byte-unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
