### PR TITLE
tagging: generic field selection, name→threshold syntax, cell-center projection

### DIFF
--- a/pyphare/pyphare/pharein/simulation.py
+++ b/pyphare/pyphare/pharein/simulation.py
@@ -571,61 +571,60 @@ def validate_restart_options(sim):
 
 
 def check_refinement(**kwargs):
-    refinement = kwargs.get("refinement", "boxes")
-    # tagging can be requested either as the legacy string "tagging" or as a
-    # dict {"tagging": {...}}; both normalize to the "tagging" refinement mode.
-    if isinstance(refinement, dict):
-        return "tagging"
-    return refinement
+    return kwargs.get("refinement", "boxes")
 
 
 def check_tagging(**kwargs):
     """Normalize tagging configuration into {"method", "quantities":[(name, thr)]}.
 
-    Returns None when refinement is not tagging. Accepts two forms:
-      - dict: refinement={"tagging": {"method": "lohner",
-                                      "quantities": {("rho", 0.1), ("B", 0.4)}}}
-      - legacy string: refinement="tagging" (+ optional tagging_threshold),
-        which maps to method "default" on B.
+    Returns None when refinement is not "tagging". Configuration is carried by the
+    optional `tagging` kwarg, e.g.
+
+        refinement="tagging",
+        tagging={"method": "default", "quantities": {"B": 0.1, "rho": 0.4}}
+
+    where `quantities` maps a field name to its own threshold (a cell is tagged if
+    ANY quantity's indicator exceeds its threshold). Both keys are optional:
+    `method` defaults to "default"; when `quantities` is omitted (or no `tagging`
+    dict is given at all) the criterion falls back to B at `tagging_threshold`
+    (kept for backward compatibility, default 0.1).
+
+    Quantity names are not restricted here: the C++ tagger resolves them against
+    the model's field tree and throws if a name matches nothing.
     """
     valid_methods = ("default", "lohner")
-    valid_quantities = ("B", "rho")
 
-    refinement = kwargs.get("refinement", "boxes")
+    if kwargs.get("refinement", "boxes") != "tagging":
+        return None
 
-    if isinstance(refinement, dict):
-        if set(refinement.keys()) != {"tagging"}:
-            raise ValueError(
-                "Error: refinement dict must have a single 'tagging' key"
-            )
-        spec = refinement["tagging"]
-        if "method" not in spec or "quantities" not in spec:
-            raise ValueError(
-                "Error: tagging dict requires both 'method' and 'quantities'"
-            )
-        method = spec["method"]
-        if method not in valid_methods:
-            raise ValueError(
-                f"Error: invalid tagging method '{method}', expected one of {valid_methods}"
-            )
-        quantities = []
-        for name, threshold in spec["quantities"]:
-            if name not in valid_quantities:
-                raise ValueError(
-                    f"Error: invalid tagging quantity '{name}', expected one of {valid_quantities}"
-                )
-            quantities.append((name, float(threshold)))
-        if len(quantities) == 0:
-            raise ValueError("Error: tagging 'quantities' cannot be empty")
-        return {"method": method, "quantities": quantities}
+    threshold = kwargs.get("tagging_threshold", 0.1)
+    if threshold is None:
+        threshold = 0.1
+    threshold = float(threshold)
 
-    if refinement == "tagging":
-        threshold = kwargs.get("tagging_threshold", 0.1)
-        if threshold is None:
-            threshold = 0.1
-        return {"method": "default", "quantities": [("B", float(threshold))]}
+    spec = kwargs.get("tagging", None)
+    if spec is None:
+        spec = {}
+    if not isinstance(spec, dict):
+        raise ValueError("Error: 'tagging' must be a dict {'method':..., 'quantities':...}")
 
-    return None
+    method = spec.get("method", "default")
+    if method not in valid_methods:
+        raise ValueError(
+            f"Error: invalid tagging method '{method}', expected one of {valid_methods}"
+        )
+
+    quantities = spec.get("quantities", None)
+    if quantities:
+        # accept the {name: threshold} mapping (preferred) or an iterable of
+        # (name, threshold) pairs.
+        items = quantities.items() if isinstance(quantities, dict) else quantities
+        quantities = [(str(name), float(thr)) for name, thr in items]
+    else:
+        # no quantities specified -> criterion applies to B at tagging_threshold
+        quantities = [("B", threshold)]
+
+    return {"method": method, "quantities": quantities}
 
 
 def check_nesting_buffer(ndim, **kwargs):
@@ -775,6 +774,7 @@ def checker(func):
             "diag_export_format",
             "refinement_boxes",
             "refinement",
+            "tagging",
             "tagging_threshold",
             "clustering",
             "smallest_patch_size",

--- a/src/amr/tagging/concrete_tagger.hpp
+++ b/src/amr/tagging/concrete_tagger.hpp
@@ -2,10 +2,10 @@
 #define PHARE_CONCRETE_TAGGER_HPP
 
 
-#include "core/def.hpp"
 #include "core/def/phare_mpi.hpp" // IWYU pragma: keep
 #include "core/data/grid/gridlayoutdefs.hpp"
 #include "core/data/ndarray/ndarray_vector.hpp"
+#include "core/data/vecfield/vecfield_component.hpp"
 #include "core/utilities/types.hpp"
 
 #include "tagger.hpp"
@@ -18,16 +18,164 @@
 
 #include <SAMRAI/pdat/CellData.h>
 
+#include <array>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 #include <stdexcept>
 
 
-
-
 namespace PHARE::amr
 {
+namespace tagger_detail
+{
+    inline std::string nameTail(std::string const& s)
+    {
+        auto const p = s.rfind('_');
+        return p == std::string::npos ? s : s.substr(p + 1);
+    }
+
+    // "EM_B_x" -> "Bx" ; otherwise empty
+    inline std::string compactComponentName(std::string const& s)
+    {
+        auto const p = s.rfind('_');
+        if (p == std::string::npos || p == 0)
+            return {};
+        auto const dir = s.substr(p + 1);
+        if (dir.size() != 1 || (dir[0] != 'x' && dir[0] != 'y' && dir[0] != 'z'))
+            return {};
+        return nameTail(s.substr(0, p)) + dir;
+    }
+
+    // Recursively walks the model's resource tree (tuples returned by
+    // getCompileTimeResourcesViewList) and pushes every scalar Field whose name matches one of
+    // the requested strings. A TensorField (e.g. VecField) matching by name expands to all its
+    // components. A scalar Field matches by full name, last token, or compact "Bx" form.
+    template<typename FieldPtr, typename Node>
+    void collectFields(std::vector<FieldPtr>& out, std::vector<std::string> const& want, Node& node)
+    {
+        auto const matches = [&](std::string const& full, bool acceptCompact) {
+            for (auto const& w : want)
+            {
+                if (w == full || w == nameTail(full))
+                    return true;
+                if (acceptCompact && w == compactComponentName(full))
+                    return true;
+            }
+            return false;
+        };
+
+        if constexpr (requires {
+                          node.components();
+                          node.name();
+                      })
+        {
+            // TensorField (rank >= 1): match by vector name, else recurse into components.
+            if (matches(node.name(), /*acceptCompact=*/false))
+            {
+                std::apply([&](auto&... c) { (out.push_back(&c), ...); }, node.components());
+            }
+            else
+            {
+                std::apply([&](auto&... c) { (collectFields<FieldPtr>(out, want, c), ...); },
+                           node.components());
+            }
+        }
+        else if constexpr (requires {
+                               node.name();
+                               node.physicalQuantity();
+                           })
+        {
+            // Scalar Field.
+            if (matches(node.name(), /*acceptCompact=*/true))
+                out.push_back(&node);
+        }
+        else if constexpr (requires { node.getCompileTimeResourcesViewList(); })
+        {
+            std::apply([&](auto&... c) { (collectFields<FieldPtr>(out, want, c), ...); },
+                       node.getCompileTimeResourcesViewList());
+        }
+        // else: unrelated node (e.g. ion population vector entries) — ignored.
+    }
+
+} // namespace tagger_detail
+
+
+//-----------------------------------------------------------------------------
+//  ConcreteTaggerKernel: the pure criterion + boundary-mask logic for a single
+//  patch. Non-polymorphic and free of SAMRAI plumbing, so it is directly
+//  unit-testable against lightweight model fixtures (which only need to expose
+//  get_B()/get_B1(), the optional state tree, and the inner-boundary geometry).
+//-----------------------------------------------------------------------------
+
+template<typename Model>
+class ConcreteTaggerKernel
+{
+    using gridlayout_type           = typename Model::gridlayout_type;
+    static auto constexpr dimension = Model::dimension;
+
+    // Default magnetic field: hybrid stores B in electromag, MHD stores it directly in the
+    // state; lightweight test models expose get_B(). Also seeds the field_type alias below.
+    static auto& defaultB_(Model& model)
+    {
+        if constexpr (requires { model.get_B(); })
+            return model.get_B();
+        else if constexpr (solver::is_hybrid_model_v<Model>)
+            return model.state.electromag.B;
+        else if constexpr (solver::is_mhd_model_v<Model>)
+            return model.state.B;
+        else
+            static_assert(core::dependent_false_v<Model>);
+    }
+
+public:
+    using vecfield_t = std::decay_t<decltype(defaultB_(std::declval<Model&>()))>;
+    using field_type = typename vecfield_t::field_type;
+
+private:
+    struct QuantityTag
+    {
+        std::string name;
+        double threshold;
+    };
+
+public:
+    ConcreteTaggerKernel(initializer::PHAREDict const& dict)
+        : method_{parseTaggingMethod(dict["method"].template to<std::string>())}
+    {
+        auto const nbrQuantities = dict["nbr_quantities"].template to<int>();
+        for (int i = 0; i < nbrQuantities; ++i)
+        {
+            auto const path        = "Q" + std::to_string(i);
+            std::string const name = dict[path]["name"].template to<std::string>();
+            double const threshold = dict[path]["threshold"].template to<double>();
+            quantities_.push_back({name, threshold});
+        }
+    }
+
+    // criterion on a single patch (writes the SAMRAI tag buffer, no ghosts).
+    void tagFields(Model& model, gridlayout_type const& layout, int* tags) const
+    {
+        tagCells_(model, layout, tags);
+    }
+
+private:
+    void tagCells_(Model& model, gridlayout_type const& layout, int* tags) const;
+    std::vector<field_type const*> components_(Model& model, std::string const& qty) const;
+
+    static std::vector<field_type const*> defaultBComponents_(Model& model);
+
+    TaggingMethod method_;
+    std::vector<QuantityTag> quantities_;
+};
+
+
+//-----------------------------------------------------------------------------
+//  ConcreteTagger: the Tagger the integrator registers. Owns a kernel and adds
+//  the SAMRAI patch plumbing + model.tags persistence around it.
+//-----------------------------------------------------------------------------
+
 template<typename Model>
 class ConcreteTagger : public Tagger
 {
@@ -36,59 +184,18 @@ class ConcreteTagger : public Tagger
     using IPhysicalModel  = PHARE::solver::IPhysicalModel<amr_t>;
     using gridlayout_type = typename Model::gridlayout_type;
 
-    static auto constexpr dimension = Model::dimension;
-
-    // hybrid stores B in electromag, MHD stores it directly in the state; static
-    // so it can also seed the field_type alias below.
-    static auto& modelB(Model& model)
-    {
-        if constexpr (solver::is_hybrid_model_v<Model>)
-            return model.state.electromag.B;
-        else if constexpr (solver::is_mhd_model_v<Model>)
-            return model.state.B;
-        else
-            static_assert(core::dependent_false_v<Model>);
-    }
-
-    using vecfield_t = std::decay_t<decltype(modelB(std::declval<Model&>()))>;
-    using field_type = typename vecfield_t::field_type;
-
-    struct QuantityTag
-    {
-        std::string name;
-        double threshold;
-    };
-
 public:
     ConcreteTagger(initializer::PHAREDict const& dict)
         : Tagger{Model::model_name == "HybridModel" ? "HybridTagger" : "MHDTagger"}
-        , method_{parseTaggingMethod(dict["method"].template to<std::string>())}
+        , kernel_{dict}
     {
-        auto const nbrQuantities = dict["nbr_quantities"].template to<int>();
-        for (int i = 0; i < nbrQuantities; ++i)
-        {
-            auto const path        = "Q" + std::to_string(i);
-            std::string const name = dict[path]["name"].template to<std::string>();
-            double const threshold = dict[path]["threshold"].template to<double>();
-            if (!supported_(name))
-                throw std::runtime_error("tagging quantity '" + name
-                                         + "' is not supported for this model");
-            quantities_.push_back({name, threshold});
-        }
     }
 
     void tag(IPhysicalModel& model, patch_t& patch, int tag_index) override;
 
 private:
-    void tagCells_(Model& model, gridlayout_type const& layout, int* tags) const;
-    std::vector<field_type const*> components_(Model& model, std::string const& qty) const;
-    static bool supported_(std::string const& qty);
-
-    TaggingMethod method_;
-    std::vector<QuantityTag> quantities_;
+    ConcreteTaggerKernel<Model> kernel_;
 };
-
-
 
 
 //-----------------------------------------------------------------------------
@@ -96,41 +203,41 @@ private:
 //-----------------------------------------------------------------------------
 
 
-
-
 template<typename Model>
-bool ConcreteTagger<Model>::supported_(std::string const& qty)
+std::vector<typename ConcreteTaggerKernel<Model>::field_type const*>
+ConcreteTaggerKernel<Model>::defaultBComponents_(Model& model)
 {
-    if (qty == "B")
-        return true;
-    if (qty == "rho")
-        return solver::is_mhd_model_v<Model>;
-    return false;
+    using Comp = PHARE::core::Component;
+    auto& B    = defaultB_(model);
+    return {&B.getComponent(Comp::X), &B.getComponent(Comp::Y), &B.getComponent(Comp::Z)};
 }
 
 
 template<typename Model>
-std::vector<typename ConcreteTagger<Model>::field_type const*>
-ConcreteTagger<Model>::components_(Model& model, std::string const& qty) const
+std::vector<typename ConcreteTaggerKernel<Model>::field_type const*>
+ConcreteTaggerKernel<Model>::components_(Model& model, std::string const& qty) const
 {
+    // "B" keeps the legacy default semantics (B1-preferred magnetic components). Any other
+    // name is resolved generically against the model's resource tree (e.g. "rho", "V", "Bx").
     if (qty == "B")
-    {
-        auto&& [bx, by, bz] = modelB(model)();
-        return {&bx, &by, &bz};
-    }
-    if (qty == "rho")
-    {
-        if constexpr (solver::is_mhd_model_v<Model>)
-            return {&model.state.rho};
-        else
-            throw std::runtime_error("rho tagging not yet supported on hybrid");
-    }
-    throw std::runtime_error("unknown tagging quantity '" + qty + "'");
+        return defaultBComponents_(model);
+
+    std::vector<field_type const*> out;
+    if constexpr (requires { model.state; })
+        tagger_detail::collectFields<field_type const*>(out, {qty}, model.state);
+    else
+        tagger_detail::collectFields<field_type const*>(out, {qty}, model);
+
+    if (out.empty())
+        throw std::runtime_error("tagging quantity '" + qty
+                                 + "' matched no field for this model");
+    return out;
 }
 
 
 template<typename Model>
-void ConcreteTagger<Model>::tagCells_(Model& model, gridlayout_type const& layout, int* tags) const
+void ConcreteTaggerKernel<Model>::tagCells_(Model& model, gridlayout_type const& layout,
+                                            int* tags) const
 {
     auto const nbrCells = layout.nbrCells();
 
@@ -143,9 +250,9 @@ void ConcreteTagger<Model>::tagCells_(Model& model, gridlayout_type const& layou
     // its own threshold. Zero once, then only ever set to 1.
     std::fill(tags, tags + core::product(nbrCells), 0);
 
-    // We loop on cell indexes for all quantities regardless of their centering
-    // (co-indexing, see tagging_criteria.hpp). The centered stencil reaches +/-1,
-    // valid at every physical cell since nbrGhosts >= 1, so no clamp is needed.
+    // We loop on dual-cell indexes; each component is projected onto the cell center
+    // by its CellCenteredSampler (see tagging_criteria.hpp). Primal and dual share the
+    // same physicalStartIndex, so a primal field is read at the same integer base.
     std::array<std::uint32_t, dimension> start;
     start[0] = layout.physicalStartIndex(core::QtyCentering::dual, core::Direction::X);
     if constexpr (dimension > 1)
@@ -153,33 +260,60 @@ void ConcreteTagger<Model>::tagCells_(Model& model, gridlayout_type const& layou
     if constexpr (dimension > 2)
         start[2] = layout.physicalStartIndex(core::QtyCentering::dual, core::Direction::Z);
 
+    // The cell-center projection reaches +1 and the centered stencil reaches +/-1, so a
+    // primal-in-d component touches up to i+2 in d. The bottom cell is always safe; the top
+    // cell needs nbrGhosts >= 2. Skip the outermost physical cell per direction otherwise.
+    auto nLoop = nbrCells;
+    if constexpr (gridlayout_type::nbrGhosts() < 2)
+        for (std::size_t d = 0; d < dimension; ++d)
+            if (nLoop[d] > 0)
+                nLoop[d] -= 1;
+
+    using sampler_t = CellCenteredSampler<dimension, field_type>;
+
     for (auto const& q : quantities_)
     {
         auto const comps = components_(model, q.name);
 
+        // one cell-center sampler per component, carrying that component's own centering.
+        std::vector<sampler_t> samplers;
+        samplers.reserve(comps.size());
+        for (auto const* c : comps)
+        {
+            auto const ctr = layout.centering(*c);
+            std::array<bool, dimension> isPrimal;
+            for (std::size_t d = 0; d < dimension; ++d)
+                isPrimal[d] = (ctr[d] == core::QtyCentering::primal);
+            samplers.emplace_back(*c, isPrimal);
+        }
+        std::vector<sampler_t const*> sampPtrs;
+        sampPtrs.reserve(samplers.size());
+        for (auto const& s : samplers)
+            sampPtrs.push_back(&s);
+
         auto const indicator = [&](std::array<std::uint32_t, dimension> const& idx) {
-            return method_ == TaggingMethod::Lohner ? lohnerIndicator<dimension>(comps, idx)
-                                                    : defaultIndicator<dimension>(comps, idx);
+            return method_ == TaggingMethod::Lohner ? lohnerIndicator<dimension>(sampPtrs, idx)
+                                                    : defaultIndicator<dimension>(sampPtrs, idx);
         };
 
         if constexpr (dimension == 1)
         {
-            for (std::uint32_t iCell = 0; iCell < nbrCells[0]; ++iCell)
+            for (std::uint32_t iCell = 0; iCell < nLoop[0]; ++iCell)
                 if (indicator({start[0] + iCell}) > q.threshold)
                     tagsv(iCell) = 1;
         }
         else if constexpr (dimension == 2)
         {
-            for (std::uint32_t ix = 0; ix < nbrCells[0]; ++ix)
-                for (std::uint32_t iy = 0; iy < nbrCells[1]; ++iy)
+            for (std::uint32_t ix = 0; ix < nLoop[0]; ++ix)
+                for (std::uint32_t iy = 0; iy < nLoop[1]; ++iy)
                     if (indicator({start[0] + ix, start[1] + iy}) > q.threshold)
                         tagsv(ix, iy) = 1;
         }
         else if constexpr (dimension == 3)
         {
-            for (std::uint32_t ix = 0; ix < nbrCells[0]; ++ix)
-                for (std::uint32_t iy = 0; iy < nbrCells[1]; ++iy)
-                    for (std::uint32_t iz = 0; iz < nbrCells[2]; ++iz)
+            for (std::uint32_t ix = 0; ix < nLoop[0]; ++ix)
+                for (std::uint32_t iy = 0; iy < nLoop[1]; ++iy)
+                    for (std::uint32_t iz = 0; iz < nLoop[2]; ++iz)
                         if (indicator({start[0] + ix, start[1] + iy, start[2] + iz}) > q.threshold)
                             tagsv(ix, iy, iz) = 1;
         }
@@ -196,7 +330,8 @@ void ConcreteTagger<Model>::tag(PHARE::solver::IPhysicalModel<amr_t>& model, pat
     auto modelIsOnPatch = concreteModel.setOnPatch(patch);
     auto pd   = dynamic_cast<SAMRAI::pdat::CellData<int>*>(patch.getPatchData(tag_index).get());
     auto tags = pd->getPointer();
-    tagCells_(concreteModel, layout, tags);
+
+    kernel_.tagFields(concreteModel, layout, tags);
 
 
     // These tags will be saved even if they are not used in diags during this advance
@@ -236,4 +371,4 @@ void ConcreteTagger<Model>::tag(PHARE::solver::IPhysicalModel<amr_t>& model, pat
 
 } // namespace PHARE::amr
 
-#endif
+#endif // PHARE_CONCRETE_TAGGER_HPP

--- a/src/amr/tagging/tagging_criteria.hpp
+++ b/src/amr/tagging/tagging_criteria.hpp
@@ -21,11 +21,14 @@ namespace PHARE::amr
 //  which matters for cell-centered (ddd) fields like the MHD mass density.
 //
 //  The criteria are evaluated per cell and produce a cell-centered indicator.
-//  Components are co-indexed on the same cell index regardless of their true
-//  centering (B is primal in its own direction, rho is cell-/node-centered):
-//  this is the legacy behavior and is exact for cell-centered quantities; for
-//  primal components it carries a harmless half-cell offset in the vector norm.
-//  Tagging is only a refinement hint, so we deliberately avoid any projection.
+//  Components must be sampled AT the cell center: a component is generally
+//  staggered (B is primal in its own direction, hybrid rho is all-primal, MHD
+//  rho is all-dual), so reading it at the dual cell index would offset it half a
+//  cell in every primal direction and break the symmetry of the centered stencil.
+//  CellCenteredSampler (below) projects each component onto the cell center on the
+//  fly (order-2 averaging of the bracketing primal nodes, dual directions read
+//  directly) with no temporary buffer. The criteria below are centering-agnostic:
+//  they call elem(i...) on whatever sampler they are given.
 //
 //  The criteria generalize over an arbitrary list of field components
 //  (B -> 3 components, rho -> 1) and combine over directions by max.
@@ -57,6 +60,65 @@ double at(Field const& f, std::array<std::uint32_t, dim> const& idx)
 {
     return std::apply([&](auto... i) { return static_cast<double>(f(i...)); }, idx);
 }
+
+
+// Samples a (possibly staggered) field AT the cell center, projecting on the fly:
+// in each PRIMAL direction it averages the two bracketing nodes (order-2,
+// PrimalToDual: at dual cell i -> 0.5*(F[i] + F[i+1])); DUAL directions are read
+// directly. No temporary buffer. An all-dual mask is an exact passthrough.
+//
+// The +1 reach in primal directions stacks with the criteria's +/-1 centered
+// stencil: a primal-in-d component touches [i-1, i+2] in d, so the top physical
+// cell needs nbrGhosts >= 2 (the caller guards this).
+template<std::size_t dim, typename Field>
+class CellCenteredSampler
+{
+public:
+    CellCenteredSampler(Field const& f, std::array<bool, dim> const& isPrimal)
+        : f_{&f}
+        , isPrimal_{isPrimal}
+    {
+    }
+
+    template<typename... Indices>
+    double operator()(Indices... is) const
+    {
+        static_assert(sizeof...(Indices) == dim, "index count must match dimension");
+        std::array<std::uint32_t, dim> const idx{static_cast<std::uint32_t>(is)...};
+
+        // tensor product over the bracketing nodes: dual dirs contribute {offset 0,
+        // coef 1}; primal dirs contribute {offset 0 and +1, coef 0.5 each}.
+        double acc = 0.0;
+        for (unsigned mask = 0; mask < (1u << dim); ++mask)
+        {
+            double coef = 1.0;
+            auto j      = idx;
+            bool valid  = true;
+            for (std::size_t d = 0; d < dim; ++d)
+            {
+                bool const bit = (mask >> d) & 1u;
+                if (isPrimal_[d])
+                {
+                    coef *= 0.5;
+                    if (bit)
+                        j[d] += 1;
+                }
+                else if (bit)
+                {
+                    valid = false; // dual direction has no +1 corner
+                    break;
+                }
+            }
+            if (valid)
+                acc += coef * at<dim>(*f_, j);
+        }
+        return acc;
+    }
+
+private:
+    Field const* f_;
+    std::array<bool, dim> isPrimal_;
+};
 
 
 // "default" criterion: centered analog of the legacy per-component smoothness

--- a/tests/amr/tagging/test_tagging.cpp
+++ b/tests/amr/tagging/test_tagging.cpp
@@ -13,11 +13,15 @@
 
 #include <cmath>
 #include <vector>
+#include <utility>
+#include <string>
 #include <algorithm>
 
 using namespace PHARE::amr;
+using namespace PHARE::core;
 
-// dict in the runtime contract: method + nbr_quantities + Q{i}/{name,threshold}
+
+// runtime dict contract: method + nbr_quantities + Q{i}/{name,threshold}
 PHARE::initializer::PHAREDict taggingDict(std::string const& method,
                                           std::vector<std::pair<std::string, double>> const& qtys)
 {
@@ -26,12 +30,17 @@ PHARE::initializer::PHAREDict taggingDict(std::string const& method,
     dict["nbr_quantities"] = static_cast<int>(qtys.size());
     for (std::size_t i = 0; i < qtys.size(); ++i)
     {
-        auto const path        = "Q" + std::to_string(i);
+        auto const path         = "Q" + std::to_string(i);
         dict[path]["name"]      = qtys[i].first;
         dict[path]["threshold"] = qtys[i].second;
     }
     return dict;
 }
+
+
+//-----------------------------------------------------------------------------
+//  Construction (uses a real model type; ctor does not touch the model)
+//-----------------------------------------------------------------------------
 
 TEST(test_tagger, constructsWithValidMethodAndQuantity)
 {
@@ -53,15 +62,10 @@ TEST(test_tagger, throwsOnUnknownMethod)
     EXPECT_THROW((ConcreteTagger<hybrid_model>{dict}), std::runtime_error);
 }
 
-TEST(test_tagger, throwsOnHybridRho)
-{
-    auto static constexpr opts = PHARE::SimOpts{1ul, 1ul, 2ul};
-    using phare_types          = PHARE::solver::PHARE_Types<opts>;
-    using hybrid_model         = phare_types::HybridModel_t;
-    auto dict                  = taggingDict("default", {{"rho", 0.1}});
-    EXPECT_THROW((ConcreteTagger<hybrid_model>{dict}), std::runtime_error);
-}
 
+//-----------------------------------------------------------------------------
+//  Pure criteria (tagging_criteria.hpp)
+//-----------------------------------------------------------------------------
 
 // minimal 1D field for testing the pure criteria functions directly
 struct MockField1D
@@ -113,207 +117,199 @@ TEST(test_criteria, parseTaggingMethod)
     EXPECT_THROW(parseTaggingMethod("nope"), std::runtime_error);
 }
 
-
-using Param   = std::vector<double>;
-using RetType = std::shared_ptr<PHARE::core::Span<double>>;
-
-RetType step1(Param const& x)
+// A field PRIMAL in x sampled at the dual cell index sits half a cell off, which
+// breaks the symmetry of the centered stencil. CellCenteredSampler projects it onto
+// the cell center (averaging bracketing nodes) and restores symmetry. Here a tent
+// peaked on node 10 is symmetric about cell center 9.5: the projected indicator must
+// satisfy ind(9)==ind(10); the raw co-indexed read does NOT (that is the bug).
+TEST(test_criteria, cellCenteredProjectionRestoresSymmetry)
 {
-    std::vector<double> values(x.size());
-    std::transform(std::begin(x), std::end(x), std::begin(values),
-                   [](auto xx) { return std::tanh((xx - 0.52) / 0.05); });
-    return std::make_shared<PHARE::core::VectorSpan<double>>(std::move(values));
-}
+    MockField1D f;
+    f.data.resize(21);
+    for (std::size_t i = 0; i < f.data.size(); ++i)
+        f.data[i] = -std::abs(static_cast<double>(i) - 10.0); // tent peaked at node 10
 
-RetType step2(Param const& x, Param const& y)
-{
-    throw std::runtime_error("fix me");
-}
+    // primal-in-x sampler -> projects to cell center; dual sampler -> raw passthrough
+    CellCenteredSampler<1, MockField1D> primal{f, {true}};
+    CellCenteredSampler<1, MockField1D> dual{f, {false}};
+    std::vector<CellCenteredSampler<1, MockField1D> const*> projected{&primal};
+    std::vector<CellCenteredSampler<1, MockField1D> const*> raw{&dual};
 
-template<std::size_t dim>
-auto constexpr step_fn()
-{
-    if constexpr (dim == 1)
-        return &step1;
-    if constexpr (dim == 2)
-        return &step2;
-}
+    auto const dProj9  = defaultIndicator<1>(projected, {9u});
+    auto const dProj10 = defaultIndicator<1>(projected, {10u});
+    EXPECT_NEAR(dProj9, dProj10, 1e-12); // projected: symmetric about cell 9.5
 
+    auto const lProj9  = lohnerIndicator<1>(projected, {9u});
+    auto const lProj10 = lohnerIndicator<1>(projected, {10u});
+    EXPECT_NEAR(lProj9, lProj10, 1e-12);
 
-template<std::size_t dim>
-PHARE::initializer::PHAREDict createDict()
-{
-    using InitFunctionT        = PHARE::initializer::InitFunction<dim>;
-    auto static constexpr step = step_fn<dim>();
-
-    PHARE::initializer::PHAREDict dict;
-    dict["ions"]["nbrPopulations"] = std::size_t{2};
-    dict["ions"]["pop0"]["name"]   = std::string{"protons"};
-    dict["ions"]["pop0"]["mass"]   = 1.;
-    dict["ions"]["pop0"]["particle_initializer"]["name"]
-        = std::string{"MaxwellianParticleInitializer"};
-    dict["ions"]["pop0"]["particle_initializer"]["density"] = static_cast<InitFunctionT>(step);
-
-    dict["ions"]["pop0"]["particle_initializer"]["bulk_velocity_x"]
-        = static_cast<InitFunctionT>(step);
-
-    dict["ions"]["pop0"]["particle_initializer"]["bulk_velocity_y"]
-        = static_cast<InitFunctionT>(step);
-
-    dict["ions"]["pop0"]["particle_initializer"]["bulk_velocity_z"]
-        = static_cast<InitFunctionT>(step);
-
-    dict["ions"]["pop0"]["particle_initializer"]["thermal_velocity_x"]
-        = static_cast<InitFunctionT>(step);
-
-    dict["ions"]["pop0"]["particle_initializer"]["thermal_velocity_y"]
-        = static_cast<InitFunctionT>(step);
-
-    dict["ions"]["pop0"]["particle_initializer"]["thermal_velocity_z"]
-        = static_cast<InitFunctionT>(step);
-
-
-    dict["ions"]["pop0"]["particle_initializer"]["nbrPartPerCell"] = int{100};
-    dict["ions"]["pop0"]["particle_initializer"]["charge"]         = -1.;
-    dict["ions"]["pop0"]["particle_initializer"]["basis"]          = std::string{"Cartesian"};
-
-    dict["ions"]["pop1"]["name"] = std::string{"alpha"};
-    dict["ions"]["pop1"]["mass"] = 1.;
-    dict["ions"]["pop1"]["particle_initializer"]["name"]
-        = std::string{"MaxwellianParticleInitializer"};
-    dict["ions"]["pop1"]["particle_initializer"]["density"] = static_cast<InitFunctionT>(step);
-
-    dict["ions"]["pop1"]["particle_initializer"]["bulk_velocity_x"]
-        = static_cast<InitFunctionT>(step);
-
-    dict["ions"]["pop1"]["particle_initializer"]["bulk_velocity_y"]
-        = static_cast<InitFunctionT>(step);
-
-    dict["ions"]["pop1"]["particle_initializer"]["bulk_velocity_z"]
-        = static_cast<InitFunctionT>(step);
-
-
-    dict["ions"]["pop1"]["particle_initializer"]["thermal_velocity_x"]
-        = static_cast<InitFunctionT>(step);
-
-    dict["ions"]["pop1"]["particle_initializer"]["thermal_velocity_y"]
-        = static_cast<InitFunctionT>(step);
-
-    dict["ions"]["pop1"]["particle_initializer"]["thermal_velocity_z"]
-        = static_cast<InitFunctionT>(step);
-
-
-    dict["ions"]["pop1"]["particle_initializer"]["nbrPartPerCell"] = int{100};
-    dict["ions"]["pop1"]["particle_initializer"]["charge"]         = -1.;
-    dict["ions"]["pop1"]["particle_initializer"]["basis"]          = std::string{"Cartesian"};
-
-    dict["electromag"]["name"]             = std::string{"EM"};
-    dict["electromag"]["electric"]["name"] = std::string{"E"};
-    dict["electromag"]["magnetic"]["name"] = std::string{"B"};
-
-    dict["electromag"]["magnetic"]["initializer"]["x_component"] = static_cast<InitFunctionT>(step);
-    dict["electromag"]["magnetic"]["initializer"]["y_component"] = static_cast<InitFunctionT>(step);
-    dict["electromag"]["magnetic"]["initializer"]["z_component"] = static_cast<InitFunctionT>(step);
-
-    dict["electrons"]["pressure_closure"]["name"] = std::string{"isothermal"};
-    dict["electrons"]["pressure_closure"]["Te"]   = 0.12;
-
-    return dict;
+    // raw co-indexing is asymmetric (regression guard: the projection is what fixes it)
+    auto const dRaw9  = defaultIndicator<1>(raw, {9u});
+    auto const dRaw10 = defaultIndicator<1>(raw, {10u});
+    EXPECT_GT(std::abs(dRaw9 - dRaw10), 0.1);
 }
 
 
+//-----------------------------------------------------------------------------
+//  Per-quantity field selection (generic resource-tree resolver) + union
+//-----------------------------------------------------------------------------
 
-template<std::size_t dim_, std::size_t interp_, std::size_t refinedPartNbr_>
-struct TaggingTestInfo
+namespace
 {
-    auto static constexpr dim            = dim_;
-    auto static constexpr interp         = interp_;
-    auto static constexpr refinedPartNbr = refinedPartNbr_;
+constexpr std::size_t ib_tagger_dim    = 2;
+constexpr std::size_t ib_tagger_interp = 1;
+using IBTaggerGridLayout = GridLayout<GridLayoutImplYee<ib_tagger_dim, ib_tagger_interp>>;
+} // namespace
+
+namespace
+{
+struct TagFieldsMockState
+{
+    UsableVecField<ib_tagger_dim>& B;
+    UsableVecField<ib_tagger_dim>& E;
+    auto getCompileTimeResourcesViewList() { return std::forward_as_tuple(B, E); }
+    auto getCompileTimeResourcesViewList() const { return std::forward_as_tuple(B, E); }
 };
 
-
-template<typename TaggingTestInfo_t>
-struct TestTagger : public ::testing::Test
+struct TagFieldsMockModel
 {
-    auto static constexpr dim            = TaggingTestInfo_t::dim;
-    auto static constexpr interp_order   = TaggingTestInfo_t::interp;
-    auto static constexpr refinedPartNbr = TaggingTestInfo_t::refinedPartNbr;
-    auto static constexpr opts           = PHARE::SimOpts{dim, interp_order, refinedPartNbr};
+    using gridlayout_type                  = IBTaggerGridLayout;
+    static constexpr std::size_t dimension = ib_tagger_dim;
 
-    using phare_types = PHARE::solver::PHARE_Types<opts>;
-    using Electromag  = phare_types::Electromag_t;
-    using Ions        = phare_types::Ions_t;
-    using Electrons   = phare_types::Electrons_t;
-    using GridLayoutT = GridLayout<GridLayoutImplYee<dim, interp_order>>;
+    TagFieldsMockState state;
+    UsableVecField<ib_tagger_dim>* B_ptr = nullptr;
 
-    struct SinglePatchHybridModel
+    auto& get_B() { return *B_ptr; }
+};
+
+// fill component (ix,iy) with `ix` -> gradient large enough to tag every cell at threshold=0.1
+template<typename Field, typename Layout, typename Qty>
+void fillRamp(Field& f, Layout const& layout, Qty qty)
+{
+    auto const alloc = layout.allocSize(qty);
+    for (std::size_t ix = 0; ix < alloc[0]; ++ix)
+        for (std::size_t iy = 0; iy < alloc[1]; ++iy)
+            f(ix, iy) = static_cast<double>(ix);
+}
+
+template<typename Field, typename Layout, typename Qty>
+void fillZero(Field& f, Layout const& layout, Qty qty)
+{
+    auto const alloc = layout.allocSize(qty);
+    for (std::size_t ix = 0; ix < alloc[0]; ++ix)
+        for (std::size_t iy = 0; iy < alloc[1]; ++iy)
+            f(ix, iy) = 0.0;
+}
+} // namespace
+
+
+TEST(TagFields, EquantityTagsOnEOnly)
+{
+    constexpr std::size_t dim = ib_tagger_dim;
+    auto const layout         = TestGridLayout<IBTaggerGridLayout>::make(20);
+
+    // B identically zero, E_y a ramp -> "B" tags nothing, "E" tags everything.
+    UsableVecField<dim> B{"B", layout, HybridQuantity::Vector::B};
+    UsableVecField<dim> E{"E", layout, HybridQuantity::Vector::E};
+    fillZero(B.getComponent(PHARE::core::Component::Y), layout, HybridQuantity::Scalar::By);
+    fillRamp(E.getComponent(PHARE::core::Component::Y), layout, HybridQuantity::Scalar::Ey);
+
+    TagFieldsMockModel model{TagFieldsMockState{B, E}, &B};
+    auto const ncells = layout.nbrCells();
+
+    std::vector<int> tagsB(ncells[0] * ncells[1], 0);
+    ConcreteTaggerKernel<TagFieldsMockModel>{taggingDict("default", {{"B", 0.1}})}.tagFields(
+        model, layout, tagsB.data());
+
+    std::vector<int> tagsE(ncells[0] * ncells[1], 0);
+    ConcreteTaggerKernel<TagFieldsMockModel>{taggingDict("default", {{"E", 0.1}})}.tagFields(
+        model, layout, tagsE.data());
+
+    bool constexpr fortran = false;
+    auto tagsBv            = NdArrayView<dim, int, fortran>(tagsB.data(), ncells);
+    auto tagsEv            = NdArrayView<dim, int, fortran>(tagsE.data(), ncells);
+    for (auto const& p : boxFromNbrCells(ncells))
     {
-        using gridlayout_type           = GridLayout<GridLayoutImplYee<dim, interp_order>>;
-        static auto constexpr dimension = dim;
-        HybridState<Electromag, Ions, Electrons> state;
-    };
-
-    GridLayoutT layout;
-
-    UsableVecField<dim> B, E;
-
-    SinglePatchHybridModel model;
-    std::vector<int> tags;
-
-    TestTagger()
-        : layout{TestGridLayout<GridLayoutT>::make(20)}
-        , B{"EM_B", layout, HybridQuantity::Vector::B}
-        , E{"EM_E", layout, HybridQuantity::Vector::E}
-        , model{createDict<dim>()}
-        , tags(20 + layout.nbrGhosts(PHARE::core::QtyCentering::dual))
-    {
-        B.set_on(model.state.electromag.B);
-        E.set_on(model.state.electromag.E);
-        model.state.electromag.initialize(layout);
+        EXPECT_EQ(tagsBv(p.toArray()), 0) << "B should be 0 with zero B";
+        EXPECT_EQ(tagsEv(p.toArray()), 1) << "E ramp should tag";
     }
-};
-
-using TaggingTestInfos = testing::Types<TaggingTestInfo<1, 1, 2> /*, TaggingTestInfo<2, 1, 4>*/>;
-TYPED_TEST_SUITE(TestTagger, TaggingTestInfos);
-
-// TODOmaybe find a way to test the tagging?
-TYPED_TEST(TestTagger, scaledAvg)
-{
-    /*
-      auto strat = DefaultHybridTaggerStrategy<SinglePatchHybridModel>();
-      strat.tag(model, layout, tags.data());
-      {
-          auto start
-              = layout.physicalStartIndex(PHARE::core::QtyCentering::dual,
-      PHARE::core::Direction::X); auto end =
-      layout.physicalEndIndex(PHARE::core::QtyCentering::dual, PHARE::core::Direction::X);
-
-          auto endCell     = layout.nbrCells()[0] - 1;
-          double threshold = 0.1;
-
-
-          for (auto iCell = 0u, ix = start; iCell <= endCell; ++ix, ++iCell)
-          {
-              auto Bxavg = (Bx(ix - 1) + Bx(ix) + Bx(ix + 1)) / 3.;
-              auto Byavg = (By(ix - 1) + By(ix) + By(ix + 1)) / 3.;
-              auto Bzavg = (Bz(ix - 1) + Bz(ix) + Bz(ix + 1)) / 3.;
-
-              auto diffx = std::abs(Bxavg - Bx(ix));
-              auto diffy = std::abs(Byavg - By(ix));
-              auto diffz = std::abs(Bzavg - Bz(ix));
-
-              auto max = std::max({diffx, diffy, diffz});
-              if (max > threshold)
-              {
-                  tags[iCell] = 1;
-              }
-              else
-                  tags[iCell] = 0;
-          }
-      }
-  */
 }
 
+
+TEST(TagFields, BxCompactNameSelectsSingleComponent)
+{
+    constexpr std::size_t dim = ib_tagger_dim;
+    auto const layout         = TestGridLayout<IBTaggerGridLayout>::make(20);
+
+    UsableVecField<dim> B{"B", layout, HybridQuantity::Vector::B};
+    UsableVecField<dim> E{"E", layout, HybridQuantity::Vector::E};
+    // Bx has a ramp, By/Bz zero -> "Bx" tags everywhere, "By" tags nothing.
+    fillRamp(B.getComponent(PHARE::core::Component::X), layout, HybridQuantity::Scalar::Bx);
+
+    TagFieldsMockModel model{TagFieldsMockState{B, E}, &B};
+    auto const ncells = layout.nbrCells();
+
+    std::vector<int> tagsBx(ncells[0] * ncells[1], 0);
+    ConcreteTaggerKernel<TagFieldsMockModel>{taggingDict("default", {{"Bx", 0.1}})}.tagFields(
+        model, layout, tagsBx.data());
+
+    std::vector<int> tagsBy(ncells[0] * ncells[1], 0);
+    ConcreteTaggerKernel<TagFieldsMockModel>{taggingDict("default", {{"By", 0.1}})}.tagFields(
+        model, layout, tagsBy.data());
+
+    bool constexpr fortran = false;
+    auto tagsBxv           = NdArrayView<dim, int, fortran>(tagsBx.data(), ncells);
+    auto tagsByv           = NdArrayView<dim, int, fortran>(tagsBy.data(), ncells);
+    for (auto const& p : boxFromNbrCells(ncells))
+    {
+        EXPECT_EQ(tagsBxv(p.toArray()), 1);
+        EXPECT_EQ(tagsByv(p.toArray()), 0);
+    }
+}
+
+
+TEST(TagFields, UnionTagsIfAnyQuantityExceeds)
+{
+    constexpr std::size_t dim = ib_tagger_dim;
+    auto const layout         = TestGridLayout<IBTaggerGridLayout>::make(20);
+
+    // B zero, E ramp. {("B",0.1)} alone tags nothing; {("B",0.1),("E",0.1)} tags everywhere
+    // because the union accepts a cell if ANY quantity's indicator exceeds its threshold.
+    UsableVecField<dim> B{"B", layout, HybridQuantity::Vector::B};
+    UsableVecField<dim> E{"E", layout, HybridQuantity::Vector::E};
+    fillZero(B.getComponent(PHARE::core::Component::Y), layout, HybridQuantity::Scalar::By);
+    fillRamp(E.getComponent(PHARE::core::Component::Y), layout, HybridQuantity::Scalar::Ey);
+
+    TagFieldsMockModel model{TagFieldsMockState{B, E}, &B};
+    auto const ncells = layout.nbrCells();
+
+    std::vector<int> tags(ncells[0] * ncells[1], 0);
+    ConcreteTaggerKernel<TagFieldsMockModel>{taggingDict("default", {{"B", 0.1}, {"E", 0.1}})}.tagFields(
+        model, layout, tags.data());
+
+    bool constexpr fortran = false;
+    auto tagsv             = NdArrayView<dim, int, fortran>(tags.data(), ncells);
+    for (auto const& p : boxFromNbrCells(ncells))
+        EXPECT_EQ(tagsv(p.toArray()), 1) << "union should tag via E even though B is flat";
+}
+
+
+TEST(TagFields, UnknownQuantityNameThrows)
+{
+    constexpr std::size_t dim = ib_tagger_dim;
+    auto const layout         = TestGridLayout<IBTaggerGridLayout>::make(20);
+
+    UsableVecField<dim> B{"B", layout, HybridQuantity::Vector::B};
+    UsableVecField<dim> E{"E", layout, HybridQuantity::Vector::E};
+    TagFieldsMockModel model{TagFieldsMockState{B, E}, &B};
+
+    ConcreteTaggerKernel<TagFieldsMockModel> tagger{
+        taggingDict("default", {{"bogus_does_not_exist", 0.1}})};
+    auto const ncells = layout.nbrCells();
+    std::vector<int> tags(ncells[0] * ncells[1], 0);
+
+    EXPECT_THROW(tagger.tagFields(model, layout, tags.data()), std::runtime_error);
+}
 
 
 int main(int argc, char** argv)


### PR DESCRIPTION
Builds on your Lohner + per-quantity tagging with three boundary-condition-free improvements.

## 1. Generic field selection
`ConcreteTagger` resolves any model field by name via a resource-tree walk (`collectFields`: full name, last token, or compact `"Bx"`) instead of the hardcoded `B`/`rho` switch. Tagging can now run on `V`, `rho` (including hybrid), single components, etc. Unknown names throw. Per-quantity `(name, threshold)` union kept. Split into `ConcreteTaggerKernel` (pure criterion, no SAMRAI plumbing) + `ConcreteTagger`, so the resolver is unit-testable on lightweight mock models.

## 2. Cell-center projection (fixes tag asymmetry)
Components are generally staggered (B primal in its own direction, hybrid `rho` all-primal, MHD `rho` all-dual). Reading them at the dual cell index offsets them half a cell and breaks the symmetry of the centered stencil. New `CellCenteredSampler` projects each component onto the cell center on the fly — order-2 average of the bracketing primal nodes per direction, dual directions read directly, **no temporary buffer**. `nbrGhosts < 2` top-cell guard for the projected stencil reach.

## 3. Python syntax
```python
refinement="tagging",
tagging={"method": "lohner", "quantities": {"B": 0.1, "rho": 0.4}}  # name -> threshold
```
`method` defaults to `"default"`; `tagging_threshold` kept as the B fallback when `quantities` is omitted. Quantity names no longer restricted to B/rho (C++ throws on no match).

## Tests
Generic selection (E / Bx / union / unknown-throws) + a cell-center projection symmetry test. `test-tagging` green (10/10) built on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)